### PR TITLE
feat: config file location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rent-scraper/root",
-  "version": "1.0.15-beta.2",
+  "version": "1.0.15-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rent-scraper/root",
-      "version": "1.0.15-beta.2",
+      "version": "1.0.15-beta.3",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1895 @@
+{
+  "name": "@rent-scraper/root",
+  "version": "1.0.14",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@rent-scraper/root",
+      "version": "1.0.14",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^3.0.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.30.1",
+        "@stylistic/eslint-plugin": "^5.1.0",
+        "eslint": "^9.30.1",
+        "globals": "^16.3.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.1.2",
+        "prettier": "^3.6.2",
+        "typescript-eslint": "^8.35.1"
+      },
+      "engines": {
+        "node": ">=22.x"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.8.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.35.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.5",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.2",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/types": "^8.41.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/type-utils": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.42.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.42.0",
+        "@typescript-eslint/types": "^8.42.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.42.0",
+        "@typescript-eslint/tsconfig-utils": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.35.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.35.0",
+        "@eslint/plugin-kit": "^0.3.5",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.5.1",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "16.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.0",
+        "commander": "^14.0.0",
+        "debug": "^4.4.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^9.0.3",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^1.0.2",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nano-spawn": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.42.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.42.0",
+        "@typescript-eslint/parser": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/utils": "8.42.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rent-scraper/root",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rent-scraper/root",
-      "version": "1.0.14",
+      "version": "1.0.15-beta.1",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rent-scraper/root",
-  "version": "1.0.15-beta.1",
+  "version": "1.0.15-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rent-scraper/root",
-      "version": "1.0.15-beta.1",
+      "version": "1.0.15-beta.2",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
       "prettier --write"
     ]
   },
-  "private": "true"
+  "private": "true",
+  "dependencies": {
+    "env-paths": "^3.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/root",
-  "version": "1.0.15-beta.2",
+  "version": "1.0.15-beta.3",
   "license": "MIT",
   "description": "Tools for scraping rent data",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/root",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "license": "MIT",
   "description": "Tools for scraping rent data",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/root",
-  "version": "1.0.15-beta.1",
+  "version": "1.0.15-beta.2",
   "license": "MIT",
   "description": "Tools for scraping rent data",
   "files": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/api",
-  "version": "1.0.15-beta.2",
+  "version": "1.0.15-beta.3",
   "type": "module",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/api",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "type": "module",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/api",
-  "version": "1.0.15-beta.1",
+  "version": "1.0.15-beta.2",
   "type": "module",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/api/src/redfin/scrape-redfin-data.ts
+++ b/packages/api/src/redfin/scrape-redfin-data.ts
@@ -2,6 +2,7 @@ import dayjs from 'dayjs'
 import * as cheerio from 'cheerio'
 
 import { parseRedfinResponse } from './get-redfin-region-id.js'
+import { throwError } from '@rent-scraper/utils'
 
 export const getHtmlFromRedfinListingUrl = async (url: string): Promise<{ data: string }> => {
   const data = await fetchHtmlFromRedfinListingUrl(url)
@@ -89,6 +90,6 @@ export const fetchHtmlFromRedfinListingUrl = async (url: string, options?: Redfi
     return data
   } else {
     const message = JSON.parse(await response?.text())?.error ?? response?.statusText
-    throw new Error(message)
+    throwError(message)
   }
 }

--- a/packages/api/src/zillow/check-for-zillow-bot-filtering.ts
+++ b/packages/api/src/zillow/check-for-zillow-bot-filtering.ts
@@ -22,7 +22,7 @@ export const checkForZillowBotFiltering = async (options?: CheckForZillowBotFilt
   try {
     const zillowZipCodes = await getZillowZipCodes()
     if (!zillowZipCodes) {
-      return throwError('zip codes required, please run the createConfig script')
+      throwError('zip codes required, please run the createConfig script')
     }
     const { fetchListings = false } = options ?? {}
     const LA_COUNTY_REGION_ID = 3101

--- a/packages/browser-server/package.json
+++ b/packages/browser-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/browser-server",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/browser-server/package.json
+++ b/packages/browser-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/browser-server",
-  "version": "1.0.15-beta.2",
+  "version": "1.0.15-beta.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/browser-server/package.json
+++ b/packages/browser-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/browser-server",
-  "version": "1.0.15-beta.1",
+  "version": "1.0.15-beta.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rent-scraper",
-  "version": "1.0.15-beta.2",
+  "version": "1.0.15-beta.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rent-scraper",
-  "version": "1.0.15-beta.1",
+  "version": "1.0.15-beta.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rent-scraper",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/cli/src/bin/run-rent-scraper.ts
+++ b/packages/cli/src/bin/run-rent-scraper.ts
@@ -6,8 +6,9 @@ import { runRentScraper } from '../index.js'
 
 const args = minimist(process.argv.slice(2))
 const source = args.source ?? 'zillow'
+const configFilePath = args['config-file']
 
-runRentScraper(source)
+runRentScraper(source, configFilePath)
   .then(() => process.exit(0))
   .catch((error: any) => {
     const { message } = parseError(error)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,12 +1,30 @@
 import type { ListingsSource } from '@rent-scraper/api'
-import { checkForConfigFile } from '@rent-scraper/utils/config'
+import { checkForConfigFile, getConfigFilePath } from '@rent-scraper/utils/config'
 import { runCreateConfig, runCheckConfig, runGenerateRegionIds } from '@rent-scraper/create-config'
 import { runScrapeListings } from '@rent-scraper/scrape-listings'
+import { cancel, confirm, isCancel, log } from '@clack/prompts'
 
-export async function runRentScraper(source: ListingsSource) {
-  if (!await checkForConfigFile(source)) {
+export async function runRentScraper(source: ListingsSource, configFilePath?: string) {
+  if (!await checkForConfigFile(source, configFilePath)) {
+    if (configFilePath) {
+      const saveConfig = await confirm({
+        message: `No config file found at ${configFilePath}. Would you like to create a new config file?`,
+      })
+
+      if (isCancel(saveConfig) || !saveConfig) {
+        cancel('Create config canceled. Please try again with a different config file.')
+        return process.exit(1)
+      }
+    } else {
+      log.warning('No config file found.')
+      log.info('')
+    }
+
     // if no config file, create one
-    await runCreateConfig()
+    await runCreateConfig(source)
+  } else {
+    const configFile = configFilePath ?? await getConfigFilePath(source)
+    log.success(`Using config file found at ${configFile}`)
   }
   // confirm config and generate regionIds if needed
   await runCheckConfig(source)

--- a/packages/create-config/package.json
+++ b/packages/create-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/create-config",
-  "version": "1.0.15-beta.1",
+  "version": "1.0.15-beta.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/create-config/package.json
+++ b/packages/create-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/create-config",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/create-config/package.json
+++ b/packages/create-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/create-config",
-  "version": "1.0.15-beta.2",
+  "version": "1.0.15-beta.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/create-config/src/check-config.ts
+++ b/packages/create-config/src/check-config.ts
@@ -2,6 +2,7 @@ import { checkForAndReadConfigFile, checkForZillowCookie, checkRequiredConfigVal
 import { log } from '@clack/prompts'
 import type { ListingsSource } from '@rent-scraper/api'
 import { runBrowserServer, runConfirmBrowserLaunch } from '@rent-scraper/browser-server'
+import { throwError } from '@rent-scraper/utils'
 
 export async function runCheckConfig(source: ListingsSource) {
   if (source === 'zillow') {
@@ -18,9 +19,12 @@ export async function runCheckConfig(source: ListingsSource) {
   }
 
   const config = await checkForAndReadConfigFile(source)
+  if (!config) {
+    throwError('config required')
+  }
   const errors = checkRequiredConfigValues(source, config, 'scrape')
   if (errors.length) {
     const error = `Required fields missing in config.${source}.yaml file: ${errors.join(', ')}`
-    throw new Error(error)
+    throwError(error)
   }
 }

--- a/packages/create-config/src/create-config.ts
+++ b/packages/create-config/src/create-config.ts
@@ -15,6 +15,6 @@ export async function runCreateConfig(source?: ListingsSource) {
       await updateConfig(source)
     }
   } else {
-    await runInitConfig()
+    await runInitConfig(source)
   }
 }

--- a/packages/create-config/src/generate-region-ids.ts
+++ b/packages/create-config/src/generate-region-ids.ts
@@ -74,7 +74,7 @@ export async function generateZillowRegionIds() {
     const zipCodes = await getZipCodesFromConfig('zillow')
     // throw error if zip codes have not been added to config file.
     if (!zipCodes) {
-      return throwError('Zip codes must be added to config file.')
+      throwError('Zip codes must be added to config file.')
     }
 
     await checkForZillowBotFiltering()
@@ -104,7 +104,7 @@ export async function generateRedfinRegionIds() {
 
     // throw error if zip codes have not been added to config file.
     if (!zipCodes) {
-      return throwError('Zip codes must be added to config file.')
+      throwError('Zip codes must be added to config file.')
     }
 
     // loop through zip codes and fetch data

--- a/packages/create-config/src/init-config.ts
+++ b/packages/create-config/src/init-config.ts
@@ -27,18 +27,16 @@ const isValidZipCode = (zipCode: string) => /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zip
 export async function runInitConfig(source?: ListingsSource) {
   intro(color.inverse(' create config '))
 
-  if (sourceArg) {
-    source = sourceArg
-  }
+  let selectedSource
 
   const workspaceDir = await findWorkspaceDir(process.cwd())
 
-  if (!workspaceDir && (!await checkForPointerFile() || !source || !await readPointerFile(source))) {
+  if (!workspaceDir && (!await checkForPointerFile() || !sourceArg || !await readPointerFile(sourceArg))) {
   // inititalize config
     if (sourceArg) {
-      log.info(`Using source ${source === 'redfin' ? 'Redfin' : 'Zillow'}`)
+      log.info(`Using source ${sourceArg === 'redfin' ? 'Redfin' : 'Zillow'}`)
     } else {
-      source = await select({
+      selectedSource = await select({
         message: 'Which listings would you like to scrape?',
         initialValue: 'zillow',
         options: [
@@ -47,11 +45,13 @@ export async function runInitConfig(source?: ListingsSource) {
         ],
       }) as ListingsSource
 
-      if (isCancel(source)) {
+      if (isCancel(selectedSource)) {
         cancel('Operation cancelled')
         return process.exit(1)
       }
     }
+
+    source = sourceArg ?? selectedSource ?? source
 
     // creates pointer file and global config path
     const configDirectory = (await text({
@@ -71,23 +71,21 @@ export async function runInitConfig(source?: ListingsSource) {
   const config = source && await checkForConfigFile(source) ? await readConfigFile(source) : undefined
 
   // inititalize config
-  source = config
-    ? source
-    : await select({
-      message: 'Which listings would you like to scrape?',
-      initialValue: 'zillow',
-      options: [
-        { value: 'zillow', label: 'Zillow' },
-        { value: 'redfin', label: 'Redfin' },
-      ],
-    }) as ListingsSource
+  source = source ?? await select({
+    message: 'Which listings would you like to scrape?',
+    initialValue: 'zillow',
+    options: [
+      { value: 'zillow', label: 'Zillow' },
+      { value: 'redfin', label: 'Redfin' },
+    ],
+  }) as ListingsSource
 
   if (isCancel(source)) {
     cancel('Operation cancelled')
     return process.exit(1)
   }
 
-  const defaultPath = path.dirname(await getConfigFilePath(source as ListingsSource))
+  const defaultPath = path.dirname(await getConfigFilePath(source))
 
   // sets output path and trims the text input
   const outputPath = config?.outputPath ?? (await text({
@@ -244,7 +242,7 @@ export async function runInitConfig(source?: ListingsSource) {
       title: 'Saving config to file',
       task: async () => {
         await sleep(3000)
-        const filePath = await writeConfigFile(source as ListingsSource, data)
+        const filePath = await writeConfigFile(source, data)
         return `Saved config to ${filePath}`
       },
     },

--- a/packages/create-config/src/init-config.ts
+++ b/packages/create-config/src/init-config.ts
@@ -9,20 +9,65 @@ import {
   log,
   tasks,
 } from '@clack/prompts'
-import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
+// import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
 import type { BrowserKey } from '@rent-scraper/api'
 import type { ListingsSource } from '@rent-scraper/api'
 import { parseAbsolutePath } from '@rent-scraper/utils'
 import type { ScrapeConfig } from '@rent-scraper/utils/config'
-import { globalDir, readConfigFile, writeConfigFile } from '@rent-scraper/utils/config'
+import { checkForPointerFile, getConfigFilePath, globalDir, readConfigFile, readPointerFile, writeConfigFile, writePointerFile } from '@rent-scraper/utils/config'
+import minimist from 'minimist'
 import path from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
 import color from 'picocolors'
+const args = minimist(process.argv.slice(2))
+const sourceArg = args.source
 
 const isValidZipCode = (zipCode: string) => /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zipCode)
 
 export async function runInitConfig(source?: ListingsSource) {
   intro(color.inverse(' create config '))
+
+  if (sourceArg) {
+    source = sourceArg
+  }
+
+  // const workspaceDir = await findWorkspaceDir(process.cwd())
+  const workspaceDir = null
+
+  if (!workspaceDir && (!await checkForPointerFile() || !source || !await readPointerFile(source))) {
+  // inititalize config
+    if (sourceArg) {
+      log.info(`Using source ${source === 'redfin' ? 'Redfin' : 'Zillow'}`)
+    } else {
+      source = await select({
+        message: 'Which listings would you like to scrape?',
+        initialValue: 'zillow',
+        options: [
+          { value: 'zillow', label: 'Zillow' },
+          { value: 'redfin', label: 'Redfin' },
+        ],
+      }) as ListingsSource
+
+      if (isCancel(source)) {
+        cancel('Operation cancelled')
+        return process.exit(1)
+      }
+    }
+
+    // creates pointer file and global config path
+    const configDirectory = (await text({
+      message: 'Where would like you to save the config file?',
+      placeholder: globalDir,
+      defaultValue: globalDir,
+    }) as string)?.trim()
+
+    await writePointerFile(source as ListingsSource, configDirectory)
+
+    if (isCancel(configDirectory)) {
+      cancel('Operation cancelled')
+      return process.exit(1)
+    }
+  }
 
   const config = source && await readConfigFile(source)
 
@@ -41,11 +86,11 @@ export async function runInitConfig(source?: ListingsSource) {
     return process.exit(1)
   }
 
-  const defaultPath = await findWorkspaceDir(process.cwd()) ? './rent-data' : globalDir
+  const defaultPath = path.dirname(await getConfigFilePath(source))
 
   // sets output path and trims the text input
   const outputPath = config?.outputPath ?? (await text({
-    message: 'Where would like you the data to be stored?',
+    message: 'Where would you like the data to be stored?',
     placeholder: defaultPath,
     defaultValue: defaultPath,
   }) as string)?.trim()
@@ -198,15 +243,15 @@ export async function runInitConfig(source?: ListingsSource) {
       title: 'Saving config to file',
       task: async () => {
         await sleep(3000)
-        await writeConfigFile(source, data)
-        return 'Saved config to file'
+        const filePath = await writeConfigFile(source, data)
+        return `Saved config to ${filePath}`
       },
     },
   ])
 
   await sleep(1000)
 
-  outro(`Config file saved!`)
+  outro('Config file saved!')
 
   await sleep(1000)
 

--- a/packages/create-config/src/init-config.ts
+++ b/packages/create-config/src/init-config.ts
@@ -9,7 +9,7 @@ import {
   log,
   tasks,
 } from '@clack/prompts'
-// import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
 import type { BrowserKey } from '@rent-scraper/api'
 import type { ListingsSource } from '@rent-scraper/api'
 import { parseAbsolutePath } from '@rent-scraper/utils'
@@ -31,8 +31,7 @@ export async function runInitConfig(source?: ListingsSource) {
     source = sourceArg
   }
 
-  // const workspaceDir = await findWorkspaceDir(process.cwd())
-  const workspaceDir = null
+  const workspaceDir = await findWorkspaceDir(process.cwd())
 
   if (!workspaceDir && (!await checkForPointerFile() || !source || !await readPointerFile(source))) {
   // inititalize config

--- a/packages/create-config/src/init-config.ts
+++ b/packages/create-config/src/init-config.ts
@@ -14,7 +14,7 @@ import type { BrowserKey } from '@rent-scraper/api'
 import type { ListingsSource } from '@rent-scraper/api'
 import { parseAbsolutePath } from '@rent-scraper/utils'
 import type { ScrapeConfig } from '@rent-scraper/utils/config'
-import { checkForPointerFile, getConfigFilePath, globalDir, readConfigFile, readPointerFile, writeConfigFile, writePointerFile } from '@rent-scraper/utils/config'
+import { checkForConfigFile, checkForPointerFile, getConfigFilePath, globalDir, readConfigFile, readPointerFile, writeConfigFile, writePointerFile } from '@rent-scraper/utils/config'
 import minimist from 'minimist'
 import path from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
@@ -68,24 +68,26 @@ export async function runInitConfig(source?: ListingsSource) {
     }
   }
 
-  const config = source && await readConfigFile(source)
+  const config = source && await checkForConfigFile(source) ? await readConfigFile(source) : undefined
 
   // inititalize config
-  source = source ?? await select({
-    message: 'Which listings would you like to scrape?',
-    initialValue: 'zillow',
-    options: [
-      { value: 'zillow', label: 'Zillow' },
-      { value: 'redfin', label: 'Redfin' },
-    ],
-  }) as ListingsSource
+  source = config
+    ? source
+    : await select({
+      message: 'Which listings would you like to scrape?',
+      initialValue: 'zillow',
+      options: [
+        { value: 'zillow', label: 'Zillow' },
+        { value: 'redfin', label: 'Redfin' },
+      ],
+    }) as ListingsSource
 
   if (isCancel(source)) {
     cancel('Operation cancelled')
     return process.exit(1)
   }
 
-  const defaultPath = path.dirname(await getConfigFilePath(source))
+  const defaultPath = path.dirname(await getConfigFilePath(source as ListingsSource))
 
   // sets output path and trims the text input
   const outputPath = config?.outputPath ?? (await text({
@@ -242,7 +244,7 @@ export async function runInitConfig(source?: ListingsSource) {
       title: 'Saving config to file',
       task: async () => {
         await sleep(3000)
-        const filePath = await writeConfigFile(source, data)
+        const filePath = await writeConfigFile(source as ListingsSource, data)
         return `Saved config to ${filePath}`
       },
     },

--- a/packages/create-config/src/update-config.ts
+++ b/packages/create-config/src/update-config.ts
@@ -11,11 +11,14 @@ import { readConfigFile, writeConfigFile } from '@rent-scraper/utils/config'
 import { setTimeout as sleep } from 'node:timers/promises'
 import { runInitConfig } from './init-config.js'
 import { rename } from 'node:fs/promises'
-import { parseAbsolutePath } from '@rent-scraper/utils'
+import { parseAbsolutePath, throwError } from '@rent-scraper/utils'
 import type { ScrapeConfig } from '@rent-scraper/utils/config'
 
 export async function updateConfig(source: ListingsSource) {
   const config = await readConfigFile(source)
+  if (!config) {
+    throwError('config required')
+  }
   const numZipCodes = config.zipCodes.split(', ').length
 
   const answers = [
@@ -61,14 +64,16 @@ export async function updateConfig(source: ListingsSource) {
 
   if (edit && Array.isArray(edit) && edit.length) {
     const data = await readConfigFile(source)
-    await sleep(1000)
-    await rename(parseAbsolutePath(`./config.${source}.yaml`), parseAbsolutePath(`./config.${source}.yaml.bak`))
-    for (const item of edit as keyof ScrapeConfig) {
-      delete data[item as keyof ScrapeConfig]
+    if (data) {
+      await sleep(1000)
+      await rename(parseAbsolutePath(`./config.${source}.yaml`), parseAbsolutePath(`./config.${source}.yaml.bak`))
+      for (const item of edit as keyof ScrapeConfig) {
+        delete data[item as keyof ScrapeConfig]
+      }
+      await sleep(1000)
+      await writeConfigFile(source, data)
+      await runInitConfig(source)
     }
-    await sleep(1000)
-    await writeConfigFile(source, data)
-    await runInitConfig(source)
   }
 
   if (status === 'new') {

--- a/packages/scrape-listings/package.json
+++ b/packages/scrape-listings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/scrape-listings",
-  "version": "1.0.15-beta.1",
+  "version": "1.0.15-beta.2",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/scrape-listings/package.json
+++ b/packages/scrape-listings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/scrape-listings",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/scrape-listings/package.json
+++ b/packages/scrape-listings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/scrape-listings",
-  "version": "1.0.15-beta.2",
+  "version": "1.0.15-beta.3",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/scrape-listings/src/scrape-listing-details-from-html.ts
+++ b/packages/scrape-listings/src/scrape-listing-details-from-html.ts
@@ -139,9 +139,8 @@ export const scrapeListingDetailsFromHtmlByZipCodes = async (source: ListingsSou
   log.message(path.join(outputPath, source, 'listings', path.basename(inputDirectory)))
 
   const logsDirectory = path.join(outputPath, source, 'logs')
-  if (!await checkForFile(logsDirectory)) {
-    await mkdir(logsDirectory, { recursive: true })
-  }
+  // creates logsDirectory if it doesn't exist
+  await mkdir(logsDirectory, { recursive: true })
 
   // write errors
   if (errors.get().length > 0) {

--- a/packages/scrape-listings/src/scrape-listing-html.ts
+++ b/packages/scrape-listings/src/scrape-listing-html.ts
@@ -122,11 +122,9 @@ export const scrapeListingHtmlByZipCodes = async (source: ListingsSource, zipCod
             if (!results) {
               errors.add(`empty file, ${readFilePath}`)
             } else {
-              // make output directory if it doesn't exist
+              // creates outputDirectory if it doesn't exist
               const outputSubDirectory = outputDirectory ? `${outputDirectory}/${zipCode}` : `${inputDirectory}/${zipCode}`
-              if (!await checkForFile(outputSubDirectory)) {
-                await mkdir(outputSubDirectory, { recursive: true })
-              }
+              await mkdir(outputSubDirectory, { recursive: true })
 
               if (results?.length) {
                 // loop through the listings and fetch the data
@@ -169,9 +167,8 @@ export const scrapeListingHtmlByZipCodes = async (source: ListingsSource, zipCod
   log.message(path.join(outputPath, source, 'listings', path.basename(inputDirectory)))
 
   const logsDirectory = path.join(outputPath, source, 'logs')
-  if (!await checkForFile(logsDirectory)) {
-    await mkdir(logsDirectory, { recursive: true })
-  }
+  // creates logsDirectory if it doesn't exit
+  await mkdir(logsDirectory, { recursive: true })
 
   // write errors
   if (errors.get().filter(error => !error.includes('rerun ')).length > reruns) {
@@ -233,9 +230,8 @@ export const scrapeListingHtmlByZipCodesAndListingDetails = async (source: Listi
   const redfinOutputPath = await getRedfinOutputPath()
   const outputPath = source === 'zillow' ? zillowOutputPath : redfinOutputPath
   const logsDirectory = path.join(outputPath, source, 'logs')
-  if (!await checkForFile(logsDirectory)) {
-    await mkdir(logsDirectory, { recursive: true })
-  }
+  // creates logsDirectory if it doesn't exit
+  await mkdir(logsDirectory, { recursive: true })
 
   // write errors
   if (errors.get().filter(error => !error.includes('rerun ')).length > reruns) {
@@ -260,9 +256,8 @@ export const scrapeListingHtmlByInputDirectory = async (source: ListingsSource, 
   if (!inputDirectory) {
     throwError('inputDirectory is required')
   }
-  if (!await checkForFile(outputDirectory)) {
-    await mkdir(outputDirectory, { recursive: true })
-  }
+  // creates outputDirectory if it doesn't exist
+  await mkdir(outputDirectory, { recursive: true })
 
   // check if inputDirectory exists
   if (await checkForFile(inputDirectory)) {
@@ -283,9 +278,9 @@ export const scrapeListingHtmlByInputDirectory = async (source: ListingsSource, 
   const redfinOutputPath = await getRedfinOutputPath()
   const outputPath = source === 'zillow' ? zillowOutputPath : redfinOutputPath
   const logsDirectory = path.join(outputPath, source, 'logs')
-  if (!await checkForFile(logsDirectory)) {
-    await mkdir(logsDirectory, { recursive: true })
-  }
+  // creates logsDirectory if it doesn't exit
+  await mkdir(logsDirectory, { recursive: true })
+
   const errorsFileName = `${path.basename(inputDirectory)}-html-errors.txt`
   const errorsPath = path.join(logsDirectory, errorsFileName)
 
@@ -308,9 +303,8 @@ export const scrapeListingHtmlByIds = async (source: ListingsSource, ids: string
   if (!outputDirectory) {
     throwError('outputDirectory is required')
   }
-  if (!await checkForFile(outputDirectory)) {
-    await mkdir(outputDirectory, { recursive: true })
-  }
+  // creates outputDirectory if it doesn't exist
+  await mkdir(outputDirectory, { recursive: true })
 
   await Promise.all(ids.map(async (id) => {
     const url = generateUrlFromId(source, id)

--- a/packages/scrape-listings/src/scrape-listings.ts
+++ b/packages/scrape-listings/src/scrape-listings.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import axios from 'axios'
 import { mkdir, writeFile } from 'fs/promises'
 import { type ZipCode, checkForZillowBotFiltering, waitForSolvedZillowCaptcha } from '@rent-scraper/api'
-import { checkForFile, compareArrays, parseError, throwError } from '@rent-scraper/utils'
+import { compareArrays, parseError, throwError } from '@rent-scraper/utils'
 import type { ScrapeListingsByZipCodesOptions, ScrapeZillowListingsByZipCodesOptions } from './types.js'
 import { scrapeListingDetailsFromHtmlByZipCodes } from './scrape-listing-details-from-html.js'
 import { scrapeListingHtmlByZipCodes } from './scrape-listing-html.js'
@@ -107,9 +107,8 @@ export async function runScrapeListings() {
         const invalidZipCodes = compareArrays(zipCodes, validZipCodes)
         const invalidZipCodesData = invalidZipCodes.join('\n')
 
-        if (!await checkForFile(logsDirectory)) {
-          await mkdir(logsDirectory, { recursive: true })
-        }
+        // creates logsDirectory if it doesn't exit
+        await mkdir(logsDirectory, { recursive: true })
 
         // write results and logs
         const logScrapingResultsFileName = `${path.basename(resultsDirectory)}-scraping-results.txt`
@@ -136,9 +135,8 @@ export async function runScrapeListings() {
         const invalidZipCodes = compareArrays(zipCodes, validZipCodes)
         const invalidZipCodesData = invalidZipCodes.join('\n')
 
-        if (!await checkForFile(logsDirectory)) {
-          await mkdir(logsDirectory, { recursive: true })
-        }
+        // creates logsDirectory if it doesn't exit
+        await mkdir(logsDirectory, { recursive: true })
 
         // write results and logs
         const logScrapingResultsFileName = `${path.basename(resultsDirectory)}-scraping-results.txt`

--- a/packages/scrape-listings/src/scrape-listings.ts
+++ b/packages/scrape-listings/src/scrape-listings.ts
@@ -96,7 +96,7 @@ export async function runScrapeListings() {
     const redfinZipCodes = await getRedfinZipCodes()
     for (let run = 1; run <= runs; run++) {
       if (!redfinZipCodes) {
-        return throwError('zip codes required, please run the createConfig script')
+        throwError('zip codes required, please run the createConfig script')
       }
       const zipCodes = redfinZipCodes
 
@@ -124,7 +124,7 @@ export async function runScrapeListings() {
     const zillowZipCodes = await getZillowZipCodes()
     for (let run = 1; run <= runs; run++) {
       if (!zillowZipCodes) {
-        return throwError('zip codes required, please run the createConfig script')
+        throwError('zip codes required, please run the createConfig script')
       }
       const zipCodes = zillowZipCodes
 

--- a/packages/scrape-listings/src/scrape-redfin-listing-results.ts
+++ b/packages/scrape-listings/src/scrape-redfin-listing-results.ts
@@ -33,10 +33,8 @@ export const scrapeRedfinListingResultsByZipCodes = async (zipCodes: number[], o
   const rerunZipCodes = [] as ZipCode[]
   const doRerun = rerunZipCodes.length
 
-  // make output directory if it doesn't exist
-  if (!await checkForFile(outputDirectory)) {
-    await mkdir(outputDirectory, { recursive: true })
-  }
+  // creates outputDirectory if it doesn't exit
+  await mkdir(outputDirectory, { recursive: true })
 
   for (let i = 1; i <= reruns + 1; i++) {
     if (reruns > 0 && i > 1) {
@@ -61,9 +59,8 @@ export const scrapeRedfinListingResultsByZipCodes = async (zipCodes: number[], o
 
   const redfinOutputPath = await getRedfinOutputPath()
   const logsDirectory = path.join(redfinOutputPath, 'redfin', 'logs')
-  if (!await checkForFile(logsDirectory)) {
-    await mkdir(logsDirectory, { recursive: true })
-  }
+  // creates logsDirectory if it doesn't exit
+  await mkdir(logsDirectory, { recursive: true })
 
   // write errors
   if (errors.get().filter(error => !error.includes('rerun ')).length > reruns) {

--- a/packages/scrape-listings/src/scrape-zillow-listing-results.ts
+++ b/packages/scrape-listings/src/scrape-zillow-listing-results.ts
@@ -43,10 +43,8 @@ export const scrapeZillowListingResultsByZipCodes = async (zipCodes: number[], o
   const rerunZipCodes = [] as ZipCode[]
   const doRerun = rerunZipCodes.length
 
-  // make output directory if it doesn't exist
-  if (!await checkForFile(outputDirectory)) {
-    await mkdir(outputDirectory, { recursive: true })
-  }
+  // creates outputDirectory if it doesn't exist
+  await mkdir(outputDirectory, { recursive: true })
 
   const s = spinner()
   s.start('Scraping Zillow search results')
@@ -74,9 +72,8 @@ export const scrapeZillowListingResultsByZipCodes = async (zipCodes: number[], o
   log.message(path.join(zillowOutputPath, 'zillow', 'results', path.basename(outputDirectory)))
 
   const logsDirectory = path.join(zillowOutputPath, 'zillow', 'logs')
-  if (!await checkForFile(logsDirectory)) {
-    await mkdir(logsDirectory, { recursive: true })
-  }
+  // creates logsDirectory if it doesn't exit
+  await mkdir(logsDirectory, { recursive: true })
 
   // write errors
   if (errors.get().filter(error => !error.includes('rerun ')).length > reruns) {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,6 +37,7 @@
     "axios": "^1.10.0",
     "bumpp": "^10.2.3",
     "csv": "^6.3.11",
+    "env-paths": "^3.0.0",
     "yaml": "^2.8.0"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/utils",
-  "version": "1.0.15-beta.2",
+  "version": "1.0.15-beta.3",
   "type": "module",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/utils",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "type": "module",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent-scraper/utils",
-  "version": "1.0.15-beta.1",
+  "version": "1.0.15-beta.2",
   "type": "module",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/utils/src/config.ts
+++ b/packages/utils/src/config.ts
@@ -1,8 +1,8 @@
 import type { ListingsSource } from '@rent-scraper/api'
 import { checkForFile, parseYamlFile, throwError, writeYamlFile } from '@rent-scraper/utils'
 import type { BrowserKey } from '@rent-scraper/api'
-import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
 import axios from 'axios'
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
 import { spinner, log } from '@clack/prompts'
 import { mkdir, stat } from 'fs/promises'
 import os from 'os'
@@ -183,7 +183,6 @@ export const writePointerFile = async (source: ListingsSource, configDirectory: 
 
   // creates pointerDirectory if it doesn't exit
   await mkdir(pointerDirectory, { recursive: true })
-  // await writeFile(pointerFilePath, configDirectory)
 
   filename = filename ?? `config.${source}.yaml`
   const configFilePath = path.join(configDirectory, filename)
@@ -231,6 +230,7 @@ export const updateConfigFile = async (source: ListingsSource, payload: any) => 
 
 export const writeConfigFile = async (source: ListingsSource, config: ScrapeConfig) => {
   const filePath = await getConfigFilePath(source)
+  await mkdir(path.dirname(filePath), { recursive: true })
   await writeYamlFile(filePath, config)
   return filePath
 }

--- a/packages/utils/src/config.ts
+++ b/packages/utils/src/config.ts
@@ -1,6 +1,7 @@
 import type { ListingsSource } from '@rent-scraper/api'
 import { checkForFile, parseYamlFile, throwError, writeYamlFile } from '@rent-scraper/utils'
 import type { BrowserKey } from '@rent-scraper/api'
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
 import axios from 'axios'
 import { spinner, log } from '@clack/prompts'
 import { mkdir, stat } from 'fs/promises'
@@ -22,8 +23,7 @@ export const pointerFilePath = path.join(paths, 'config.yaml')
 export const globalDir = path.join(os.homedir(), 'rent-scraper')
 
 export const getConfigFilePath = async (source: ListingsSource) => {
-  // const workspaceDir = await findWorkspaceDir(process.cwd()
-  const workspaceDir = null
+  const workspaceDir = await findWorkspaceDir(process.cwd())
   if (workspaceDir) {
     return source === 'redfin' ? path.join(workspaceDir, 'config.redfin.yaml') : path.join(workspaceDir, 'config.zillow.yaml')
   } else {

--- a/packages/utils/src/config.ts
+++ b/packages/utils/src/config.ts
@@ -1,12 +1,12 @@
 import type { ListingsSource } from '@rent-scraper/api'
 import { checkForFile, parseYamlFile, throwError, writeYamlFile } from '@rent-scraper/utils'
-import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
 import type { BrowserKey } from '@rent-scraper/api'
 import axios from 'axios'
 import { spinner, log } from '@clack/prompts'
-import { mkdir } from 'fs/promises'
+import { mkdir, stat } from 'fs/promises'
 import os from 'os'
 import path from 'path'
+import envPaths from 'env-paths'
 
 export interface ScrapeConfig {
   outputPath: string
@@ -17,37 +17,49 @@ export interface ScrapeConfig {
   browser?: BrowserKey
   zillowCookie?: string
 }
-
+const paths = envPaths('rent-scraper').config
+export const pointerFilePath = path.join(paths, 'config.yaml')
 export const globalDir = path.join(os.homedir(), 'rent-scraper')
 
 export const getConfigFilePath = async (source: ListingsSource) => {
-  // uses global directory if using npx (not in the workspace)
-  const workspaceDir = await findWorkspaceDir(process.cwd())
-  if (!workspaceDir) {
-    if (!await checkForFile(globalDir)) {
-      await mkdir(globalDir, { recursive: true })
+  // const workspaceDir = await findWorkspaceDir(process.cwd()
+  const workspaceDir = null
+  if (workspaceDir) {
+    return source === 'redfin' ? path.join(workspaceDir, 'config.redfin.yaml') : path.join(workspaceDir, 'config.zillow.yaml')
+  } else {
+    if (await checkForPointerFile()) {
+      return await readPointerFile(source)
     }
   }
-  const configDir = workspaceDir ?? globalDir
-  return source === 'redfin' ? path.join(configDir, 'config.redfin.yaml') : path.join(configDir, 'config.zillow.yaml')
 }
 
-export const checkForConfigFile = async (source: ListingsSource) => {
-  const configFile = await getConfigFilePath(source)
-  return await checkForFile(configFile)
+export const checkForConfigFile = async (source: ListingsSource, configFilePath?: string) => {
+  const configFile = configFilePath ?? await getConfigFilePath(source)
+  if (configFile) {
+    return await checkForFile(configFile)
+  }
+}
+
+export const checkForPointerFile = async () => {
+  return await checkForFile(pointerFilePath)
 }
 
 export const checkForAndReadConfigFile = async (source: ListingsSource) => {
   const configFile = await getConfigFilePath(source)
-  if (!await checkForFile(configFile)) {
-    throwError('Config file is required.')
+  if (configFile) {
+    if (!await checkForFile(configFile)) {
+      throwError('Config file is required.')
+    }
+    return await parseYamlFile(configFile) as ScrapeConfig
   }
-  return await parseYamlFile(configFile) as ScrapeConfig
 }
 
 export const resetZillowCookie = async () => {
-  const { zillowCookie, ...config } = await readConfigFile('zillow')
-  await writeConfigFile('zillow', config)
+  const configFile = await readConfigFile('zillow')
+  if (configFile) {
+    const { zillowCookie, ...config } = configFile ?? {}
+    await writeConfigFile('zillow', config)
+  }
 }
 
 export const waitForConfigFile = async (source: ListingsSource) => {
@@ -118,7 +130,7 @@ export const checkForZillowCookie = async () => {
   return await getValueFromConfigFile('zillow', 'zillowCookie')
 }
 
-export const checkRequiredConfigValues = (source: ListingsSource, config: ScrapeConfig, task = 'init') => {
+export const checkRequiredConfigValues = (source: ListingsSource, config?: ScrapeConfig, task = 'init') => {
   const { outputPath, zipCodes, browser, zillowCookie } = config ?? {}
   const errors = []
   if (!outputPath) {
@@ -149,7 +161,49 @@ export const stringifyZipCodes = (zipCodes: number[]) => {
 
 export const readConfigFile = async (source: ListingsSource) => {
   const configFile = await getConfigFilePath(source)
-  return await parseYamlFile(configFile) as ScrapeConfig
+  if (configFile) {
+    return await parseYamlFile(configFile) as ScrapeConfig
+  }
+}
+
+export const writePointerFile = async (source: ListingsSource, configDirectory: string, filename?: string) => {
+  if (!path.isAbsolute(configDirectory)) {
+    throwError('configDirectory must be an absolute path')
+  }
+
+  const stats = await stat(configDirectory).catch(() => null)
+  if (stats && !stats.isDirectory()) {
+    throwError(`${configDirectory} exists but is not a directory`)
+  }
+
+  // creates configDirectory if it doesn't exit
+  await mkdir(configDirectory, { recursive: true })
+
+  const pointerDirectory = path.dirname(pointerFilePath)
+
+  // creates pointerDirectory if it doesn't exit
+  await mkdir(pointerDirectory, { recursive: true })
+  // await writeFile(pointerFilePath, configDirectory)
+
+  filename = filename ?? `config.${source}.yaml`
+  const configFilePath = path.join(configDirectory, filename)
+  const configData = {
+    ...await parseYamlFile(pointerFilePath),
+    [source]: configFilePath,
+  }
+
+  await writeYamlFile(pointerFilePath, configData)
+  const pointer = await parseYamlFile(pointerFilePath) ?? {}
+  return pointer?.[source]
+}
+
+export const readPointerFile = async (source: ListingsSource) => {
+  try {
+    // get data from pointerFile
+    return (await parseYamlFile(pointerFilePath))?.[source]
+  } catch (err: any) {
+    console.error(`Failed to read pointer file at ${pointerFilePath}: ${err.message}`)
+  }
 }
 
 export const getOutputPathFromConfig = async (source: ListingsSource) => {
@@ -176,11 +230,7 @@ export const updateConfigFile = async (source: ListingsSource, payload: any) => 
 }
 
 export const writeConfigFile = async (source: ListingsSource, config: ScrapeConfig) => {
-  const workspaceDir = await findWorkspaceDir(process.cwd())
-  const configDir = workspaceDir ?? globalDir
-  if (source === 'redfin') {
-    return await writeYamlFile(path.join(configDir, 'config.redfin.yaml'), config)
-  } else {
-    return await writeYamlFile(path.join(configDir, 'config.zillow.yaml'), config)
-  }
+  const filePath = await getConfigFilePath(source)
+  await writeYamlFile(filePath, config)
+  return filePath
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,7 +16,7 @@ export const isObject = (data: Record<string, unknown>): boolean => typeof data 
 
 export const isEmptyObject = (data: Record<string, unknown>): boolean => isObject(data) && Object.keys(data).length === 0
 
-export function throwError(message: string, status?: number): void {
+export function throwError(message: string, status?: number): never {
   throw new Error(JSON.stringify({ status: status ?? 400, message }))
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      env-paths:
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.30.1
@@ -62,7 +66,7 @@ importers:
     dependencies:
       '@clack/prompts':
         specifier: alpha
-        version: 1.0.0-alpha.4
+        version: 1.0.0-alpha.7
       '@rent-scraper/api':
         specifier: workspace:*
         version: link:../api
@@ -105,7 +109,7 @@ importers:
     dependencies:
       '@clack/prompts':
         specifier: alpha
-        version: 1.0.0-alpha.4
+        version: 1.0.0-alpha.7
       '@rent-scraper/api':
         specifier: workspace:*
         version: link:../api
@@ -154,7 +158,7 @@ importers:
         version: 3.883.0
       '@clack/prompts':
         specifier: alpha
-        version: 1.0.0-alpha.4
+        version: 1.0.0-alpha.7
       '@google-cloud/storage':
         specifier: ^7.16.0
         version: 7.17.0
@@ -203,7 +207,7 @@ importers:
     dependencies:
       '@clack/prompts':
         specifier: alpha
-        version: 1.0.0-alpha.4
+        version: 1.0.0-alpha.7
       '@rent-scraper/api':
         specifier: workspace:*
         version: link:../api
@@ -240,7 +244,7 @@ importers:
     dependencies:
       '@clack/prompts':
         specifier: alpha
-        version: 1.0.0-alpha.4
+        version: 1.0.0-alpha.7
       '@rent-scraper/api':
         specifier: workspace:*
         version: link:../api
@@ -253,6 +257,9 @@ importers:
       csv:
         specifier: ^6.3.11
         version: 6.4.1
+      env-paths:
+        specifier: ^3.0.0
+        version: 3.0.0
       yaml:
         specifier: ^2.8.0
         version: 2.8.1
@@ -422,11 +429,11 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
-  '@clack/core@1.0.0-alpha.4':
-    resolution: {integrity: sha512-VCtU+vjyKPMSakVrB9q1bOnXN7QW/w4+YQDQCOF59GrzydW+169i0fVx/qzRRXJgt8KGj/pZZ/JxXroFZIDByg==}
+  '@clack/core@1.0.0-alpha.7':
+    resolution: {integrity: sha512-3vdh6Ar09D14rVxJZIm3VQJkU+ZOKKT5I5cC0cOVazy70CNyYYjiwRj9unwalhESndgxx6bGc/m6Hhs4EKF5XQ==}
 
-  '@clack/prompts@1.0.0-alpha.4':
-    resolution: {integrity: sha512-KnmtDF2xQGoI5AlBme9akHtvCRV0RKAARUXHBQO2tMwnY8B08/4zPWigT7uLK25UPrMCEqnyQPkKRjNdhPbf8g==}
+  '@clack/prompts@1.0.0-alpha.7':
+    resolution: {integrity: sha512-BLB8LYOdfI4q6XzDl8la69J/y/7s0tHjuU1/5ak+o8yB2BPZBNE22gfwbFUIEmlq/BGBD6lVUAMR7w+1K7Pr6Q==}
 
   '@esbuild/aix-ppc64@0.25.9':
     resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
@@ -1680,6 +1687,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -3571,14 +3582,14 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
-  '@clack/core@1.0.0-alpha.4':
+  '@clack/core@1.0.0-alpha.7':
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.0.0-alpha.4':
+  '@clack/prompts@1.0.0-alpha.7':
     dependencies:
-      '@clack/core': 1.0.0-alpha.4
+      '@clack/core': 1.0.0-alpha.7
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
@@ -4921,6 +4932,8 @@ snapshots:
   entities@6.0.1: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   environment@1.1.0: {}
 


### PR DESCRIPTION
closes #2 

if the user is within the npm workspace dir, it will default to saving the zillow.config.yaml and redfin.config.yaml from within the workspace dir (cwd)

if outside the npm workspace and running the scraper with npx...

#### uses a pointer file stored in a default directory determined by [env-paths](https://www.npmjs.com/package/env-paths/v/0.2.0) library

```
MacOS: /Users/[username]/Library/Preferences/rent-scraper-nodejs/config.yaml
```

#### the config.yaml file points to the location of the config files for zillow and redfin

```
zillow: /Users/[username]/rent-scraper/config.zillow.yaml
redfin: /Users/[username]/rent-scraper/config.redfin.yaml
```

#### detects source and run using from `--config-file` arg
```
rent-scrape --config-file=[path-to-config-file]
```